### PR TITLE
Fix carrier config saving on newer Android

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools">
 
+    <instrumentation
+            android:name=".manager.PrivilegedCarrierConfigInstrumentation"
+            android:targetPackage="${applicationId}"/>
+
     <application
             android:allowBackup="true"
             android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/github/nrfr/manager/CarrierConfigManager.kt
+++ b/app/src/main/java/com/github/nrfr/manager/CarrierConfigManager.kt
@@ -84,7 +84,12 @@ object CarrierConfigManager {
         }
     }
 
-    fun setCarrierConfig(subId: Int, countryCode: String?, carrierName: String? = null) {
+    fun setCarrierConfig(
+        context: Context,
+        subId: Int,
+        countryCode: String?,
+        carrierName: String? = null
+    ): Boolean {
         val bundle = PersistableBundle()
 
         // 设置国家码
@@ -101,14 +106,14 @@ object CarrierConfigManager {
             bundle.putString(CarrierConfigManager.KEY_CARRIER_NAME_STRING, carrierName)
         }
 
-        overrideCarrierConfig(subId, bundle)
+        return overrideCarrierConfig(context, subId, bundle)
     }
 
-    fun resetCarrierConfig(subId: Int) {
-        overrideCarrierConfig(subId, null)
+    fun resetCarrierConfig(context: Context, subId: Int): Boolean {
+        return overrideCarrierConfig(context, subId, null)
     }
 
-    private fun overrideCarrierConfig(subId: Int, bundle: PersistableBundle?) {
+    private fun overrideCarrierConfig(context: Context, subId: Int, bundle: PersistableBundle?): Boolean {
         val carrierConfigLoader = ICarrierConfigLoader.Stub.asInterface(
             ShizukuBinderWrapper(
                 TelephonyFrameworkInitializer
@@ -117,6 +122,16 @@ object CarrierConfigManager {
                     .get()
             )
         )
-        carrierConfigLoader.overrideConfig(subId, bundle, true)
+        try {
+            carrierConfigLoader.overrideConfig(subId, bundle, true)
+            return false
+        } catch (e: SecurityException) {
+            if (e.message?.contains("cannot be invoked by shell") == true) {
+                PrivilegedCarrierConfigRunner.overrideConfig(context, subId, bundle)
+                return true
+            } else {
+                throw e
+            }
+        }
     }
 }

--- a/app/src/main/java/com/github/nrfr/manager/PrivilegedCarrierConfigRunner.kt
+++ b/app/src/main/java/com/github/nrfr/manager/PrivilegedCarrierConfigRunner.kt
@@ -1,0 +1,111 @@
+package com.github.nrfr.manager
+
+import android.app.ActivityManager
+import android.app.IActivityManager
+import android.app.Instrumentation
+import android.app.UiAutomationConnection
+import android.content.ComponentName
+import android.content.Context
+import android.os.Build
+import android.os.Bundle
+import android.os.PersistableBundle
+import android.os.Process
+import android.os.ServiceManager
+import android.system.Os
+import android.telephony.CarrierConfigManager
+import org.lsposed.hiddenapibypass.HiddenApiBypass
+import rikka.shizuku.ShizukuBinderWrapper
+
+private const val ARG_CALLER_PID = "caller_pid"
+private const val ARG_SUB_ID = "sub_id"
+private const val ARG_CONFIG = "config"
+private const val ARG_RESET = "reset"
+
+object PrivilegedCarrierConfigRunner {
+    init {
+        HiddenApiBypass.addHiddenApiExemptions("L")
+        HiddenApiBypass.addHiddenApiExemptions("I")
+    }
+
+    fun overrideConfig(context: Context, subId: Int, bundle: PersistableBundle?) {
+        val args = Bundle().apply {
+            putInt(ARG_CALLER_PID, Process.myPid())
+            putInt(ARG_SUB_ID, subId)
+            putBoolean(ARG_RESET, bundle == null)
+            if (bundle != null) {
+                putParcelable(ARG_CONFIG, bundle)
+            }
+        }
+
+        val activity = ServiceManager.getService(Context.ACTIVITY_SERVICE)
+        val activityManager = IActivityManager.Stub.asInterface(ShizukuBinderWrapper(activity))
+        val component = ComponentName(context, PrivilegedCarrierConfigInstrumentation::class.java)
+        val flags = ActivityManager.INSTR_FLAG_DISABLE_HIDDEN_API_CHECKS or
+            ActivityManager.INSTR_FLAG_NO_RESTART
+
+        activityManager.startInstrumentation(
+            component,
+            null,
+            flags,
+            args,
+            null,
+            UiAutomationConnection(),
+            0,
+            null
+        )
+    }
+}
+
+class PrivilegedCarrierConfigInstrumentation : Instrumentation() {
+    init {
+        HiddenApiBypass.addHiddenApiExemptions("L")
+        HiddenApiBypass.addHiddenApiExemptions("I")
+    }
+
+    override fun onCreate(arguments: Bundle) {
+        super.onCreate(arguments)
+
+        if (arguments.getInt(ARG_CALLER_PID, 0) != Process.myPid()) {
+            finish(0, Bundle())
+            return
+        }
+
+        val activity = ServiceManager.getService(Context.ACTIVITY_SERVICE)
+        val activityManager = IActivityManager.Stub.asInterface(ShizukuBinderWrapper(activity))
+
+        val subId = arguments.getInt(ARG_SUB_ID)
+        val bundle = getPersistableBundle(arguments)
+
+        try {
+            activityManager.startDelegateShellPermissionIdentity(Os.getuid(), null)
+            overrideCarrierConfig(subId, bundle, persistent = true)
+        } catch (e: SecurityException) {
+            overrideCarrierConfig(subId, bundle, persistent = false)
+        } finally {
+            activityManager.stopDelegateShellPermissionIdentity()
+            finish(0, Bundle())
+        }
+    }
+
+    private fun overrideCarrierConfig(
+        subId: Int,
+        bundle: PersistableBundle?,
+        persistent: Boolean
+    ) {
+        val manager = targetContext.getSystemService(CarrierConfigManager::class.java)
+        manager.overrideConfig(subId, bundle, persistent)
+    }
+
+    private fun getPersistableBundle(arguments: Bundle): PersistableBundle? {
+        if (arguments.getBoolean(ARG_RESET)) {
+            return null
+        }
+
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            arguments.getParcelable(ARG_CONFIG, PersistableBundle::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            arguments.getParcelable<PersistableBundle>(ARG_CONFIG)
+        }
+    }
+}

--- a/app/src/main/java/com/github/nrfr/ui/screens/MainScreen.kt
+++ b/app/src/main/java/com/github/nrfr/ui/screens/MainScreen.kt
@@ -21,6 +21,8 @@ import com.github.nrfr.data.CountryPresets
 import com.github.nrfr.data.PresetCarriers
 import com.github.nrfr.manager.CarrierConfigManager
 import com.github.nrfr.model.SimCardInfo
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -36,6 +38,18 @@ fun MainScreen(onShowAbout: () -> Unit) {
     var isCountryCodeMenuExpanded by remember { mutableStateOf(false) }
     var isCarrierMenuExpanded by remember { mutableStateOf(false) }
     var refreshTrigger by remember { mutableStateOf(0) }
+    val scope = rememberCoroutineScope()
+
+    fun refreshConfig(delayed: Boolean) {
+        if (delayed) {
+            scope.launch {
+                delay(800)
+                refreshTrigger += 1
+            }
+        } else {
+            refreshTrigger += 1
+        }
+    }
 
     // 获取实际的 SIM 卡信息
     val simCards = remember(context, refreshTrigger) { CarrierConfigManager.getSimCards(context) }
@@ -157,9 +171,9 @@ fun MainScreen(onShowAbout: () -> Unit) {
                 customCarrierName = customCarrierName,
                 onReset = {
                     try {
-                        CarrierConfigManager.resetCarrierConfig(it.subId)
+                        val delayedRefresh = CarrierConfigManager.resetCarrierConfig(context, it.subId)
                         Toast.makeText(context, "设置已还原", Toast.LENGTH_SHORT).show()
-                        refreshTrigger += 1
+                        refreshConfig(delayedRefresh)
                         selectedCountryCode = ""
                         selectedCarrier = null
                         customCarrierName = ""
@@ -179,13 +193,14 @@ fun MainScreen(onShowAbout: () -> Unit) {
                         } else {
                             selectedCountryCode
                         }
-                        CarrierConfigManager.setCarrierConfig(
+                        val delayedRefresh = CarrierConfigManager.setCarrierConfig(
+                            context,
                             simCard.subId,
                             countryCode,
                             carrierName
                         )
                         Toast.makeText(context, "设置已保存", Toast.LENGTH_SHORT).show()
-                        refreshTrigger += 1
+                        refreshConfig(delayedRefresh)
                     } catch (e: Exception) {
                         Toast.makeText(context, "保存失败: ${e.message}", Toast.LENGTH_SHORT).show()
                     }


### PR DESCRIPTION
## Summary

Fixes saving carrier config overrides on newer Android versions where calling `CarrierConfigManager.overrideConfig` through the Shizuku shell identity fails with `overrideConfig cannot be invoked by shell`.

The fallback mirrors the workaround used by Pixel IMS / vvb2060 Ims: start an app instrumentation from the Shizuku-wrapped activity manager, then perform the override from the app process while delegating shell permissions.

## Changes

- Add `PrivilegedCarrierConfigInstrumentation` and register it in the manifest.
- Keep the existing Shizuku direct `ICarrierConfigLoader.overrideConfig(..., persistent = true)` path for older systems.
- Fall back to instrumentation only when the system rejects shell callers.
- Delay UI config refresh when the fallback path is used, so the first save tap shows the updated state correctly.

## Tested

- Built successfully with `:app:assembleDebug`.
- Built successfully with `:app:assembleRelease`.
- Manually verified saving carrier settings works on the affected newer Android system, including the first-tap refresh behavior.