### PR TITLE
支持 Android 16 运营商配置覆盖

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "com.github.nrfr"
         minSdk = 26
         targetSdk = 34
-        versionCode = 3 //版本更新 +1
-        versionName = "1.0.3" //同步更新版本号 rfr-client/app.go
+        versionCode = 4 //版本更新 +1
+        versionName = "1.0.4" //同步更新版本号 rfr-client/app.go
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
     namespace = "com.github.nrfr"
-    compileSdk = 34
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.github.nrfr"

--- a/app/src/main/java/com/github/nrfr/manager/CarrierConfigManager.kt
+++ b/app/src/main/java/com/github/nrfr/manager/CarrierConfigManager.kt
@@ -2,55 +2,123 @@ package com.github.nrfr.manager
 
 import android.content.Context
 import android.os.Build
+import android.os.IBinder
 import android.os.PersistableBundle
-import android.telephony.CarrierConfigManager
+import android.telephony.CarrierConfigManager as PlatformCarrierConfigManager
+import android.telephony.SubscriptionInfo
 import android.telephony.SubscriptionManager
-import android.telephony.TelephonyFrameworkInitializer
 import android.telephony.TelephonyManager
-import com.android.internal.telephony.ICarrierConfigLoader
 import com.github.nrfr.model.SimCardInfo
+import rikka.shizuku.Shizuku
 import rikka.shizuku.ShizukuBinderWrapper
+import java.lang.reflect.InvocationTargetException
 
 object CarrierConfigManager {
     fun getSimCards(context: Context): List<SimCardInfo> {
-        val simCards = mutableListOf<SimCardInfo>()
-        val subId1 = SubscriptionManager.getSubId(0)
-        val subId2 = SubscriptionManager.getSubId(1)
+        val simCards = getActiveSubscriptions(context).map { subscription ->
+            val slot = subscription.simSlotIndex + 1
+            val subId = subscription.subscriptionId
+            val carrierName = subscription.carrierName?.toString()
+                ?.takeIf { it.isNotBlank() }
+                ?: getCarrierNameBySubId(context, subId)
+            SimCardInfo(slot, subId, carrierName, getCurrentConfig(subId))
+        }.toMutableList()
 
-        if (subId1 != null) {
-            val config1 = getCurrentConfig(subId1[0])
-            simCards.add(SimCardInfo(1, subId1[0], getCarrierNameBySubId(context, subId1[0]), config1))
-        }
-        if (subId2 != null) {
-            val config2 = getCurrentConfig(subId2[0])
-            simCards.add(SimCardInfo(2, subId2[0], getCarrierNameBySubId(context, subId2[0]), config2))
+        if (simCards.isNotEmpty()) return simCards
+
+        for (slotIndex in 0 until getActiveModemCount(context).coerceAtLeast(2)) {
+            val subId = getSubIdForSlot(slotIndex) ?: continue
+            simCards.add(
+                SimCardInfo(
+                    slotIndex + 1,
+                    subId,
+                    getCarrierNameBySubId(context, subId),
+                    getCurrentConfig(subId)
+                )
+            )
         }
 
         return simCards
     }
 
+    private fun getActiveSubscriptions(context: Context): List<SubscriptionInfo> {
+        return try {
+            val subscriptionManager = context.getSystemService(SubscriptionManager::class.java)
+                ?: return emptyList()
+            subscriptionManager.activeSubscriptionInfoList
+                ?.filter { it.subscriptionId != SubscriptionManager.INVALID_SUBSCRIPTION_ID }
+                ?.sortedBy { it.simSlotIndex }
+                ?: emptyList()
+        } catch (_: SecurityException) {
+            emptyList()
+        } catch (_: Exception) {
+            emptyList()
+        }
+    }
+
+    private fun getActiveModemCount(context: Context): Int {
+        return try {
+            val telephonyManager = context.getSystemService(TelephonyManager::class.java)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                telephonyManager?.activeModemCount ?: 2
+            } else {
+                telephonyManager?.phoneCount ?: 2
+            }
+        } catch (_: Exception) {
+            2
+        }
+    }
+
+    private fun getSubIdForSlot(slotIndex: Int): Int? {
+        return try {
+            val getSubId = SubscriptionManager::class.java.getDeclaredMethod(
+                "getSubId",
+                Int::class.javaPrimitiveType
+            )
+            @Suppress("UNCHECKED_CAST")
+            (getSubId.invoke(null, slotIndex) as? IntArray)
+                ?.firstOrNull { it != SubscriptionManager.INVALID_SUBSCRIPTION_ID }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
     private fun getCurrentConfig(subId: Int): Map<String, String> {
         try {
-            val carrierConfigLoader = ICarrierConfigLoader.Stub.asInterface(
-                ShizukuBinderWrapper(
-                    TelephonyFrameworkInitializer
-                        .getTelephonyServiceManager()
-                        .carrierConfigServiceRegisterer
-                        .get()
+            val carrierConfigLoader = getCarrierConfigLoader()
+            val config = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                invokeCarrierConfigLoader(
+                    carrierConfigLoader,
+                    "getConfigForSubIdWithFeature",
+                    arrayOf(
+                        Int::class.javaPrimitiveType!!,
+                        String::class.java,
+                        String::class.java
+                    ),
+                    subId,
+                    "com.github.nrfr",
+                    null
                 )
-            )
-            val config = carrierConfigLoader.getConfigForSubId(subId, "com.github.nrfr") ?: return emptyMap()
+            } else {
+                invokeCarrierConfigLoader(
+                    carrierConfigLoader,
+                    "getConfigForSubId",
+                    arrayOf(Int::class.javaPrimitiveType!!, String::class.java),
+                    subId,
+                    "com.github.nrfr"
+                )
+            } as? PersistableBundle ?: return emptyMap()
 
             val result = mutableMapOf<String, String>()
 
             // 获取国家码配置
-            config.getString(CarrierConfigManager.KEY_SIM_COUNTRY_ISO_OVERRIDE_STRING)?.let {
+            config.getString(PlatformCarrierConfigManager.KEY_SIM_COUNTRY_ISO_OVERRIDE_STRING)?.let {
                 result["国家码"] = it
             }
 
             // 获取运营商名称配置
-            if (config.getBoolean(CarrierConfigManager.KEY_CARRIER_NAME_OVERRIDE_BOOL, false)) {
-                config.getString(CarrierConfigManager.KEY_CARRIER_NAME_STRING)?.let {
+            if (config.getBoolean(PlatformCarrierConfigManager.KEY_CARRIER_NAME_OVERRIDE_BOOL, false)) {
+                config.getString(PlatformCarrierConfigManager.KEY_CARRIER_NAME_STRING)?.let {
                     result["运营商名称"] = it
                 }
             }
@@ -67,8 +135,7 @@ object CarrierConfigManager {
 
         return try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                // Android 10 及以上使用新 API
-                telephonyManager.getNetworkOperatorName(subId)
+                telephonyManager.createForSubscriptionId(subId).networkOperatorName
             } else {
                 // Android 8-9 使用反射获取运营商名称
                 val createForSubscriptionId = TelephonyManager::class.java.getMethod(
@@ -90,15 +157,15 @@ object CarrierConfigManager {
         // 设置国家码
         if (!countryCode.isNullOrEmpty() && countryCode.length == 2) {
             bundle.putString(
-                CarrierConfigManager.KEY_SIM_COUNTRY_ISO_OVERRIDE_STRING,
+                PlatformCarrierConfigManager.KEY_SIM_COUNTRY_ISO_OVERRIDE_STRING,
                 countryCode.lowercase()
             )
         }
 
         // 设置运营商名称
         if (!carrierName.isNullOrEmpty()) {
-            bundle.putBoolean(CarrierConfigManager.KEY_CARRIER_NAME_OVERRIDE_BOOL, true)
-            bundle.putString(CarrierConfigManager.KEY_CARRIER_NAME_STRING, carrierName)
+            bundle.putBoolean(PlatformCarrierConfigManager.KEY_CARRIER_NAME_OVERRIDE_BOOL, true)
+            bundle.putString(PlatformCarrierConfigManager.KEY_CARRIER_NAME_STRING, carrierName)
         }
 
         overrideCarrierConfig(subId, bundle)
@@ -109,14 +176,90 @@ object CarrierConfigManager {
     }
 
     private fun overrideCarrierConfig(subId: Int, bundle: PersistableBundle?) {
-        val carrierConfigLoader = ICarrierConfigLoader.Stub.asInterface(
-            ShizukuBinderWrapper(
-                TelephonyFrameworkInitializer
-                    .getTelephonyServiceManager()
-                    .carrierConfigServiceRegisterer
-                    .get()
-            )
+        try {
+            val carrierConfigLoader = getCarrierConfigLoader()
+            try {
+                overrideCarrierConfig(carrierConfigLoader, subId, bundle, persistent = true)
+            } catch (e: InvocationTargetException) {
+                val cause = e.targetException
+                if (cause is SecurityException && cause.isPersistentWriteDenied()) {
+                    overrideCarrierConfig(carrierConfigLoader, subId, bundle, persistent = false)
+                } else {
+                    throw e
+                }
+            }
+        } catch (e: InvocationTargetException) {
+            val cause = e.targetException
+            if (cause is SecurityException) {
+                throw IllegalStateException(buildSecurityMessage(cause), cause)
+            }
+            throw IllegalStateException("写入运营商配置失败：${cause.message ?: cause.javaClass.simpleName}", cause)
+        } catch (e: Exception) {
+            throw IllegalStateException("写入运营商配置失败：${e.message ?: e.javaClass.simpleName}", e)
+        }
+    }
+
+    private fun overrideCarrierConfig(
+        loader: Any,
+        subId: Int,
+        bundle: PersistableBundle?,
+        persistent: Boolean
+    ) {
+        invokeCarrierConfigLoader(
+            loader,
+            "overrideConfig",
+            arrayOf(
+                Int::class.javaPrimitiveType!!,
+                PersistableBundle::class.java,
+                Boolean::class.javaPrimitiveType!!
+            ),
+            subId,
+            bundle,
+            persistent
         )
-        carrierConfigLoader.overrideConfig(subId, bundle, true)
+    }
+
+    private fun getCarrierConfigLoader(): Any {
+        val serviceManager = Class.forName("android.os.ServiceManager")
+        val getService = serviceManager.getDeclaredMethod("getService", String::class.java)
+        val binder = getService.invoke(null, "carrier_config") as? IBinder
+            ?: throw IllegalStateException("无法连接 carrier_config 系统服务")
+
+        val stub = Class.forName("com.android.internal.telephony.ICarrierConfigLoader\$Stub")
+        val asInterface = stub.getDeclaredMethod("asInterface", IBinder::class.java)
+        return asInterface.invoke(null, ShizukuBinderWrapper(binder))
+            ?: throw IllegalStateException("无法获取 carrier_config 接口")
+    }
+
+    private fun invokeCarrierConfigLoader(
+        loader: Any,
+        methodName: String,
+        parameterTypes: Array<Class<*>>,
+        vararg args: Any?
+    ): Any? {
+        val method = loader.javaClass.getMethod(methodName, *parameterTypes)
+        return method.invoke(loader, *args)
+    }
+
+    private fun buildSecurityMessage(error: SecurityException): String {
+        val message = error.message.orEmpty()
+        return when {
+            error.isPersistentWriteDenied() -> {
+                "系统只允许系统应用持久修改运营商配置，已无法写入持久配置"
+            }
+            message.contains("shell", ignoreCase = true) -> {
+                "Android 16 已禁止 adb/shell 模式修改运营商配置，请在 Shizuku 中使用 root 模式启动后重试"
+            }
+            Shizuku.getUid() != 0 -> {
+                "当前 Shizuku 不是 root 模式，无法在此系统上修改运营商配置"
+            }
+            else -> "系统拒绝修改运营商配置：${message.ifBlank { error.javaClass.simpleName }}"
+        }
+    }
+
+    private fun SecurityException.isPersistentWriteDenied(): Boolean {
+        val message = message.orEmpty()
+        return message.contains("persistent=true", ignoreCase = true) ||
+            message.contains("persist", ignoreCase = true)
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.suppressUnsupportedCompileSdk=36

--- a/nrfr-client/app.go
+++ b/nrfr-client/app.go
@@ -452,7 +452,7 @@ func (a *App) CheckNrfrUpdate() (bool, error) {
 	}
 
 	// 最新版本号（从build.gradle.kts中获取）
-	latestVersion := "1.0.3" // 这里硬编码为当前最新版本
+	latestVersion := "1.0.4" // 这里硬编码为当前最新版本
 
 	// 比较版本号
 	return compareVersions(currentVersion, latestVersion) < 0, nil


### PR DESCRIPTION
## 更新内容

- 兼容 Android 16：通过反射访问 `carrier_config`，避免直接依赖隐藏 API 编译符号。
- 优先读取系统活跃订阅信息，改善双卡设备的 SIM 识别。
- 当 Android 16 拒绝非系统应用写入持久运营商配置时，自动回退为非持久覆盖。
- 构建目标升级到 `compileSdk 36`。

## 修复原因

Android 16 上部分隐藏 API 编译符号不再可直接使用，并且系统会拒绝非系统应用进行持久运营商配置覆盖。原实现会在保存时失败，新的逻辑会在持久写入被拒绝时回退到非持久覆盖。

## 验证

- 已通过 `gradle :app:assembleDebug --no-daemon` 构建验证。
- 已在 OnePlus PLK110 / Android 16 / Shizuku root 模式下安装测试。
