### PR TITLE
fix: make Android 16 carrier override effective

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools">
 
+    <instrumentation
+            android:name=".manager.PrivilegedCarrierConfigInstrumentation"
+            android:targetPackage="${applicationId}"/>
+
     <application
             android:allowBackup="true"
             android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/github/nrfr/manager/CarrierConfigManager.kt
+++ b/app/src/main/java/com/github/nrfr/manager/CarrierConfigManager.kt
@@ -14,19 +14,34 @@ import rikka.shizuku.ShizukuBinderWrapper
 object CarrierConfigManager {
     fun getSimCards(context: Context): List<SimCardInfo> {
         val simCards = mutableListOf<SimCardInfo>()
-        val subId1 = SubscriptionManager.getSubId(0)
-        val subId2 = SubscriptionManager.getSubId(1)
+        val subId1 = getSubIdForSlot(0)
+        val subId2 = getSubIdForSlot(1)
 
         if (subId1 != null) {
-            val config1 = getCurrentConfig(subId1[0])
-            simCards.add(SimCardInfo(1, subId1[0], getCarrierNameBySubId(context, subId1[0]), config1))
+            val config1 = getCurrentConfig(subId1)
+            simCards.add(SimCardInfo(1, subId1, getCarrierNameBySubId(context, subId1), config1))
         }
         if (subId2 != null) {
-            val config2 = getCurrentConfig(subId2[0])
-            simCards.add(SimCardInfo(2, subId2[0], getCarrierNameBySubId(context, subId2[0]), config2))
+            val config2 = getCurrentConfig(subId2)
+            simCards.add(SimCardInfo(2, subId2, getCarrierNameBySubId(context, subId2), config2))
         }
 
         return simCards
+    }
+
+    /**
+     * Android 16 on some vendor ROMs exposes [-1] through the legacy static
+     * getSubId(slot) API even though the subscription service has a valid
+     * slot-to-subscription mapping. Resolve that mapping through the Shizuku
+     * shell only when the direct API does not return a usable ID.
+     */
+    private fun getSubIdForSlot(slotIndex: Int): Int? {
+        val directSubId = runCatching {
+            SubscriptionManager.getSubId(slotIndex)
+                ?.firstOrNull { it != SubscriptionManager.INVALID_SUBSCRIPTION_ID }
+        }.getOrNull()
+
+        return directSubId ?: PrivilegedCarrierConfigRunner.getSubIdForSlot(slotIndex)
     }
 
     private fun getCurrentConfig(subId: Int): Map<String, String> {
@@ -84,7 +99,12 @@ object CarrierConfigManager {
         }
     }
 
-    fun setCarrierConfig(subId: Int, countryCode: String?, carrierName: String? = null) {
+    fun setCarrierConfig(
+        context: Context,
+        subId: Int,
+        countryCode: String?,
+        carrierName: String? = null
+    ): Boolean {
         val bundle = PersistableBundle()
 
         // 设置国家码
@@ -101,14 +121,14 @@ object CarrierConfigManager {
             bundle.putString(CarrierConfigManager.KEY_CARRIER_NAME_STRING, carrierName)
         }
 
-        overrideCarrierConfig(subId, bundle)
+        return overrideCarrierConfig(context, subId, bundle)
     }
 
-    fun resetCarrierConfig(subId: Int) {
-        overrideCarrierConfig(subId, null)
+    fun resetCarrierConfig(context: Context, subId: Int): Boolean {
+        return overrideCarrierConfig(context, subId, null)
     }
 
-    private fun overrideCarrierConfig(subId: Int, bundle: PersistableBundle?) {
+    private fun overrideCarrierConfig(context: Context, subId: Int, bundle: PersistableBundle?): Boolean {
         val carrierConfigLoader = ICarrierConfigLoader.Stub.asInterface(
             ShizukuBinderWrapper(
                 TelephonyFrameworkInitializer
@@ -117,6 +137,19 @@ object CarrierConfigManager {
                     .get()
             )
         )
-        carrierConfigLoader.overrideConfig(subId, bundle, true)
+        try {
+            // Android 16 accepts the temporary override path on affected ROMs,
+            // while persistent=true may be silently ignored or rejected later.
+            val persistent = Build.VERSION.SDK_INT < 36
+            carrierConfigLoader.overrideConfig(subId, bundle, persistent)
+            return false
+        } catch (e: SecurityException) {
+            if (e.message?.contains("cannot be invoked by shell") == true) {
+                PrivilegedCarrierConfigRunner.overrideConfig(context, subId, bundle)
+                return true
+            } else {
+                throw e
+            }
+        }
     }
 }

--- a/app/src/main/java/com/github/nrfr/manager/PrivilegedCarrierConfigRunner.kt
+++ b/app/src/main/java/com/github/nrfr/manager/PrivilegedCarrierConfigRunner.kt
@@ -1,0 +1,172 @@
+package com.github.nrfr.manager
+
+import android.app.ActivityManager
+import android.app.IActivityManager
+import android.app.Instrumentation
+import android.app.UiAutomationConnection
+import android.content.ComponentName
+import android.content.Context
+import android.os.Build
+import android.os.Bundle
+import android.os.PersistableBundle
+import android.os.Process
+import android.os.ServiceManager
+import android.system.Os
+import android.telephony.CarrierConfigManager
+import android.telephony.SubscriptionManager
+import org.lsposed.hiddenapibypass.HiddenApiBypass
+import rikka.shizuku.Shizuku
+import rikka.shizuku.ShizukuBinderWrapper
+import java.io.InputStream
+
+private val LOGICAL_SIM_SLOT_PATTERN = Regex("""^\s*Logical SIM slot (\d+): subId=(-?\d+)""")
+
+private const val ARG_CALLER_PID = "caller_pid"
+private const val ARG_SUB_ID = "sub_id"
+private const val ARG_CONFIG = "config"
+private const val ARG_RESET = "reset"
+
+object PrivilegedCarrierConfigRunner {
+    init {
+        HiddenApiBypass.addHiddenApiExemptions("L")
+        HiddenApiBypass.addHiddenApiExemptions("I")
+    }
+
+    fun overrideConfig(context: Context, subId: Int, bundle: PersistableBundle?) {
+        val args = Bundle().apply {
+            putInt(ARG_CALLER_PID, Process.myPid())
+            putInt(ARG_SUB_ID, subId)
+            putBoolean(ARG_RESET, bundle == null)
+            if (bundle != null) {
+                putParcelable(ARG_CONFIG, bundle)
+            }
+        }
+
+        val activity = ServiceManager.getService(Context.ACTIVITY_SERVICE)
+        val activityManager = IActivityManager.Stub.asInterface(ShizukuBinderWrapper(activity))
+        val component = ComponentName(context, PrivilegedCarrierConfigInstrumentation::class.java)
+        val flags = ActivityManager.INSTR_FLAG_DISABLE_HIDDEN_API_CHECKS or
+            ActivityManager.INSTR_FLAG_NO_RESTART
+
+        activityManager.startInstrumentation(
+            component,
+            null,
+            flags,
+            args,
+            null,
+            UiAutomationConnection(),
+            0,
+            null
+        )
+    }
+
+    /** Resolve the active subscription ID when Android returns INVALID_SUBSCRIPTION_ID. */
+    fun getSubIdForSlot(slotIndex: Int): Int? {
+        val output = runCatching {
+            runShellCommand(arrayOf("dumpsys", "isub"))
+        }.getOrNull() ?: return null
+
+        return output.lineSequence().mapNotNull { line ->
+            val match = LOGICAL_SIM_SLOT_PATTERN.find(line) ?: return@mapNotNull null
+            val slot = match.groupValues[1].toIntOrNull() ?: return@mapNotNull null
+            val subId = match.groupValues[2].toIntOrNull() ?: return@mapNotNull null
+            if (slot == slotIndex && subId != SubscriptionManager.INVALID_SUBSCRIPTION_ID) {
+                subId
+            } else {
+                null
+            }
+        }.firstOrNull()
+    }
+
+    private fun runShellCommand(command: Array<String>): String {
+        val process = newShizukuProcess(command)
+        val stdout = StringBuilder()
+        val stderr = StringBuilder()
+        val stdoutThread = readAsync(process.inputStream, stdout)
+        val stderrThread = readAsync(process.errorStream, stderr)
+        val exitCode = process.waitFor()
+        stdoutThread.join()
+        stderrThread.join()
+
+        if (exitCode != 0) {
+            throw IllegalStateException(stderr.toString().ifBlank { "dumpsys isub failed: $exitCode" })
+        }
+        return stdout.toString()
+    }
+
+    private fun newShizukuProcess(command: Array<String>): Process {
+        val newProcess = Shizuku::class.java.getDeclaredMethod(
+            "newProcess",
+            Array<String>::class.java,
+            Array<String>::class.java,
+            String::class.java
+        )
+        newProcess.isAccessible = true
+        return newProcess.invoke(null, command, null, null) as Process
+    }
+
+    private fun readAsync(inputStream: InputStream, output: StringBuilder): Thread {
+        return Thread {
+            inputStream.bufferedReader().use { reader ->
+                output.append(reader.readText())
+            }
+        }.apply { start() }
+    }
+}
+
+class PrivilegedCarrierConfigInstrumentation : Instrumentation() {
+    init {
+        HiddenApiBypass.addHiddenApiExemptions("L")
+        HiddenApiBypass.addHiddenApiExemptions("I")
+    }
+
+    override fun onCreate(arguments: Bundle) {
+        super.onCreate(arguments)
+
+        if (arguments.getInt(ARG_CALLER_PID, 0) != Process.myPid()) {
+            finish(0, Bundle())
+            return
+        }
+
+        val activity = ServiceManager.getService(Context.ACTIVITY_SERVICE)
+        val activityManager = IActivityManager.Stub.asInterface(ShizukuBinderWrapper(activity))
+
+        val subId = arguments.getInt(ARG_SUB_ID)
+        val bundle = getPersistableBundle(arguments)
+
+        try {
+            activityManager.startDelegateShellPermissionIdentity(Os.getuid(), null)
+            // On Android 16 the temporary override is the effective path on
+            // vendor ROMs that accept the write but do not apply persistence.
+            val persistent = Build.VERSION.SDK_INT < 36
+            overrideCarrierConfig(subId, bundle, persistent)
+        } catch (e: SecurityException) {
+            overrideCarrierConfig(subId, bundle, persistent = false)
+        } finally {
+            activityManager.stopDelegateShellPermissionIdentity()
+            finish(0, Bundle())
+        }
+    }
+
+    private fun overrideCarrierConfig(
+        subId: Int,
+        bundle: PersistableBundle?,
+        persistent: Boolean
+    ) {
+        val manager = targetContext.getSystemService(CarrierConfigManager::class.java)
+        manager.overrideConfig(subId, bundle, persistent)
+    }
+
+    private fun getPersistableBundle(arguments: Bundle): PersistableBundle? {
+        if (arguments.getBoolean(ARG_RESET)) {
+            return null
+        }
+
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            arguments.getParcelable(ARG_CONFIG, PersistableBundle::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            arguments.getParcelable<PersistableBundle>(ARG_CONFIG)
+        }
+    }
+}

--- a/app/src/main/java/com/github/nrfr/ui/screens/MainScreen.kt
+++ b/app/src/main/java/com/github/nrfr/ui/screens/MainScreen.kt
@@ -21,6 +21,8 @@ import com.github.nrfr.data.CountryPresets
 import com.github.nrfr.data.PresetCarriers
 import com.github.nrfr.manager.CarrierConfigManager
 import com.github.nrfr.model.SimCardInfo
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -36,6 +38,18 @@ fun MainScreen(onShowAbout: () -> Unit) {
     var isCountryCodeMenuExpanded by remember { mutableStateOf(false) }
     var isCarrierMenuExpanded by remember { mutableStateOf(false) }
     var refreshTrigger by remember { mutableStateOf(0) }
+    val scope = rememberCoroutineScope()
+
+    fun refreshConfig(delayed: Boolean) {
+        if (delayed) {
+            scope.launch {
+                delay(800)
+                refreshTrigger += 1
+            }
+        } else {
+            refreshTrigger += 1
+        }
+    }
 
     // 获取实际的 SIM 卡信息
     val simCards = remember(context, refreshTrigger) { CarrierConfigManager.getSimCards(context) }
@@ -157,9 +171,9 @@ fun MainScreen(onShowAbout: () -> Unit) {
                 customCarrierName = customCarrierName,
                 onReset = {
                     try {
-                        CarrierConfigManager.resetCarrierConfig(it.subId)
+                        val delayedRefresh = CarrierConfigManager.resetCarrierConfig(context, it.subId)
                         Toast.makeText(context, "设置已还原", Toast.LENGTH_SHORT).show()
-                        refreshTrigger += 1
+                        refreshConfig(delayedRefresh)
                         selectedCountryCode = ""
                         selectedCarrier = null
                         customCarrierName = ""
@@ -179,13 +193,14 @@ fun MainScreen(onShowAbout: () -> Unit) {
                         } else {
                             selectedCountryCode
                         }
-                        CarrierConfigManager.setCarrierConfig(
+                        val delayedRefresh = CarrierConfigManager.setCarrierConfig(
+                            context,
                             simCard.subId,
                             countryCode,
                             carrierName
                         )
                         Toast.makeText(context, "设置已保存", Toast.LENGTH_SHORT).show()
-                        refreshTrigger += 1
+                        refreshConfig(delayedRefresh)
                     } catch (e: Exception) {
                         Toast.makeText(context, "保存失败: ${e.message}", Toast.LENGTH_SHORT).show()
                     }


### PR DESCRIPTION
## Summary\n\nThis is a follow-up to #127 for devices where Nrfr reports a successful save but the target service still sees the original carrier config.\n\n- ignore SubscriptionManager.INVALID_SUBSCRIPTION_ID instead of using -1 as a real target\n- resolve slot-to-subscription IDs through dumpsys isub over the existing Shizuku channel when the legacy API returns an invalid value\n- use the effective non-persistent override path on Android 16 (API 36), while retaining persistent behavior on older releases\n- keep the Android 16 instrumentation fallback from #122/#127\n\n## Validation\n\n- Redmi K80 / HyperOS / Android 16 / Shizuku\n- before: save UI reported success, but logs showed Invalid phoneId: -1 and no effective override\n- after: slot 0 resolved to subId=1; mOverrideConfigs contained sim_country_iso_override_string=us and carrier_name_string=T-Mobile USA; TikTok loaded the feed after restart\n\nThe local build check reached dependency resolution, but Maven Central returned HTTP 403 for jsr305; device validation used the patched APK recorded in the local verification artifacts.